### PR TITLE
Table options

### DIFF
--- a/interfaces.go
+++ b/interfaces.go
@@ -14,13 +14,11 @@ type Connection interface {
 
 // KeySpace is used to obtain tables from.
 type KeySpace interface {
-	MapTable(tableName, id string, row interface{}) MapTable
-	MultimapTable(tableName, fieldToIndexBy, uniqueKey string, row interface{}) MultimapTable
-	TimeSeriesTable(tableName, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) TimeSeriesTable
-	TimeSeriesTableWithName(tableName, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) TimeSeriesTable
-	MultiTimeSeriesTable(tableName, fieldToIndexByField, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) MultiTimeSeriesTable
-	MultiTimeSeriesTableWithName(tableName, fieldToIndexByField, timeField, uniqueKey string, bucketSize time.Duration, row interface{}) MultiTimeSeriesTable
-	Table(tableName string, row interface{}, keys Keys) Table
+	MapTable(tableName, id string, row interface{}, opts ...TableOptions) MapTable
+	MultimapTable(tableName, fieldToIndexBy, uniqueKey string, row interface{}, opts ...TableOptions) MultimapTable
+	TimeSeriesTable(tableName, timeField, uniqueKey string, bucketSize time.Duration, row interface{}, opts ...TableOptions) TimeSeriesTable
+	MultiTimeSeriesTable(tableName, fieldToIndexByField, timeField, uniqueKey string, bucketSize time.Duration, row interface{}, opts ...TableOptions) MultiTimeSeriesTable
+	Table(tableName string, row interface{}, keys Keys, opts ...TableOptions) Table
 	// DebugMode enables/disables debug mode depending on the value of the input boolean.
 	// When DebugMode is enabled, all built CQL statements are printe to stdout.
 	DebugMode(bool)

--- a/table.go
+++ b/table.go
@@ -26,6 +26,11 @@ type tableInfo struct {
 	fieldValues    []interface{}
 }
 
+// TableOptions contains additional optional configuration parameters to be passed to a table
+type TableOptions struct {
+	TableName string
+}
+
 func newTableInfo(keyspace, name string, keys Keys, entity interface{}, fieldSource map[string]interface{}) *tableInfo {
 	cinf := &tableInfo{
 		keyspace:      keyspace,
@@ -209,4 +214,13 @@ func (t t) CreateStatement() (string, error) {
 
 func (t t) Name() string {
 	return t.info.name
+}
+
+// mergeTableOptions is a slight misnomer - if more than one is provided we return the first
+func mergeTableOptions(opts ...TableOptions) TableOptions {
+	if len(opts) < 1 {
+		return TableOptions{}
+	}
+
+	return opts[0]
 }


### PR DESCRIPTION
 - Add optional `TableOptions` to the table constructors which takes a `gocassa.TableOptions`
 - Remove crappy `...WithName` constructors
 - `TableName` can be specified in the `TableOptions` when constructing a table